### PR TITLE
stabilize to 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "async-walkdir"
 version = "1.0.0"
 authors = ["Ririsoft <riri@ririsoft.com>"]
-edition = "2018"
+edition = "2021"
 description = "Asynchronous directory traversal for Rust."
 license = "Apache-2.0"
 keywords = ["async", "walk", "directory", "recursive", "stream"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-walkdir"
-version = "0.2.0"
+version = "1.0.0"
 authors = ["Ririsoft <riri@ririsoft.com>"]
 edition = "2018"
 description = "Asynchronous directory traversal for Rust."
@@ -14,8 +14,8 @@ exclude = [ "/.github/*" ]
 readme = "README.md"
 
 [dependencies]
-futures-lite = "1.2"
-async-fs = "1.1"
+futures-lite = "2.1.0"
+async-fs = "2.1.0"
 
 [dev-dependencies]
-tempfile = "3.1.0"
+tempfile = "3.9.0"

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ Asynchronous directory traversal for Rust.
 
 Based on [async-fs][2] and [blocking][3],
 it uses a thread pool to handle blocking IOs. Please refere to those crates for the rationale.
-This crate is compatible with any async runtime based on [futures 0.3][4],
-which includes [tokio][5], [async-std][6] and [smol][7].
+This crate is compatible with async runtimes [tokio][5], [async-std][6], [smol][7] and potentially any runtime based on [futures 0.3][4]
 
 We do not plan to be as feature full as [Walkdir][1] crate in the synchronous world, but
 do not hesitate to open an issue or a PR.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,11 +166,11 @@ where
         move |state| async move {
             match state {
                 State::Start((root, filter)) => match read_dir(root).await {
-                    Err(e) => return Some((Err(e), State::Done)),
-                    Ok(rd) => return walk(vec![rd], filter).await,
+                    Err(e) => Some((Err(e), State::Done)),
+                    Ok(rd) => walk(vec![rd], filter).await,
                 },
-                State::Walk((dirs, filter)) => return walk(dirs, filter).await,
-                State::Done => return None,
+                State::Walk((dirs, filter)) => walk(dirs, filter).await,
+                State::Done => None,
             }
         },
     )


### PR DESCRIPTION
API is being used for 3 years and has proven to be solid. It is time for 1.0.0.

Upgrade dependencies to major versions.