### PR TITLE
error: add io::Error conversion

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -27,6 +27,26 @@ impl Error {
         let InnerError::Io { ref source, .. } = self.0;
         Some(source)
     }
+
+    /// Similar to [`io`][Self::io] except consumes self to convert to the original
+    /// [`io::Error`] if one exists.
+    pub fn into_io(self) -> Option<io::Error> {
+        let InnerError::Io { source, .. } = self.0;
+        Some(source)
+    }
+}
+
+impl From<Error> for io::Error {
+    /// Convert to an [`io::Error`], preserving the original [`struct@Error`]
+    /// as the ["inner error"][io::Error::into_inner].
+    /// Note that this also makes the display of the error include the context.
+    ///
+    /// This is different from [`into_io`][Error::into_io] which returns
+    /// the original [`io::Error`].
+    fn from(err: Error) -> io::Error {
+        let InnerError::Io { ref source, .. } = err.0;
+        io::Error::new(source.kind(), err)
+    }
 }
 
 #[derive(Debug, Error)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,6 +305,21 @@ mod tests {
                 Err(e) => {
                     assert_eq!(wd.root, e.path().unwrap());
                     assert_eq!(e.io().unwrap().kind(), ErrorKind::NotFound);
+                    assert_eq!(e.into_io().unwrap().kind(), ErrorKind::NotFound);
+                }
+                _ => panic!("want IO error"),
+            }
+        })
+    }
+
+    #[test]
+    fn into_io_error() {
+        block_on(async {
+            let mut wd = WalkDir::new("foobar");
+            match wd.next().await.unwrap() {
+                Err(e) => {
+                    let e: std::io::Error = e.into();
+                    assert_eq!(e.kind(), ErrorKind::NotFound);
                 }
                 _ => panic!("want IO error"),
             }


### PR DESCRIPTION
accessing the contained io::Error solely via a ref is a bit bothering to work with.

this PR takes from [sync walkdir's `Error` allowing to extract the underlying `io::Error`](https://docs.rs/walkdir/latest/walkdir/struct.Error.html#method.io_error).
* `into_io` to extract the contained `io::Error`
* `From<Error> for io::Error` to create a more "classic" error type

note: I choose to name it `into_io()` to be consistant with `io()`, in contrario to upstream postfix theses with "_error".